### PR TITLE
Solution for åäö gets turned into ���.

### DIFF
--- a/emulated_hue/api.py
+++ b/emulated_hue/api.py
@@ -13,6 +13,7 @@ from aiohttp import web
 from emulated_hue.entertainment import EntertainmentAPI
 from emulated_hue.ssl_cert import async_generate_selfsigned_cert
 from emulated_hue.utils import update_dict
+from emulated_hue.utils import json_response_nonunicode
 
 LOGGER = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ def check_request(func):
         if "username" in request.match_info:
             username = request.match_info["username"]
             if not await cls.config.async_get_user(username):
-                return web.json_response(const.HUE_UNAUTHORIZED_USER)
+                return json_response_nonunicode(const.HUE_UNAUTHORIZED_USER)
         # check and unpack json body if needed
         if request.method in ["PUT", "POST"]:
             try:
@@ -152,7 +153,7 @@ class HueApi:
     @check_request
     async def async_get_auth(self, request: web.Request):
         """Handle requests to find the emulated hue bridge."""
-        return web.json_response(const.HUE_UNAUTHORIZED_USER)
+        return json_response_nonunicode(const.HUE_UNAUTHORIZED_USER)
 
     @routes.post("/api{tail:/?}")
     @check_request
@@ -160,29 +161,29 @@ class HueApi:
         """Handle requests to create a username for the emulated hue bridge."""
         if "devicetype" not in request_data:
             LOGGER.warning("devicetype not specified")
-            return web.json_response(("Devicetype not specified", 302))
+            return json_response_nonunicode(("Devicetype not specified", 302))
         if not self.config.link_mode_enabled:
             LOGGER.warning("Link mode is not enabled!")
             await self.config.async_enable_link_mode_discovery()
-            return web.json_response(("Link mode is not enabled!", 302))
+            return json_response_nonunicode(("Link mode is not enabled!", 302))
         userdetails = await self.config.async_create_user(request_data["devicetype"])
         response = [{"success": {"username": userdetails["username"]}}]
         if request_data.get("generateclientkey"):
             response[0]["success"]["clientkey"] = userdetails["clientkey"]
         LOGGER.info("Client %s registered", userdetails["name"])
-        return web.json_response(response)
+        return json_response_nonunicode(response)
 
     @routes.get("/api/{username}/lights")
     @check_request
     async def async_get_lights(self, request: web.Request):
         """Handle requests to retrieve the info all lights."""
-        return web.json_response(await self.__async_get_all_lights())
+        return json_response_nonunicode(await self.__async_get_all_lights())
 
     @routes.get("/api/{username}/lights/new")
     @check_request
     async def async_get_new_lights(self, request: web.Request):
         """Handle requests to retrieve new added lights to the (virtual) bridge."""
-        return web.json_response({})
+        return json_response_nonunicode({})
 
     @routes.get("/api/{username}/lights/{light_id}")
     @check_request
@@ -191,7 +192,7 @@ class HueApi:
         light_id = request.match_info["light_id"]
         entity = await self.config.async_entity_by_light_id(light_id)
         result = await self.__async_entity_to_hue(entity)
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @routes.put("/api/{username}/lights/{light_id}/state")
     @check_request
@@ -205,14 +206,14 @@ class HueApi:
         response = await self.__async_create_hue_response(
             request.path, request_data, username
         )
-        return web.json_response(response)
+        return json_response_nonunicode(response)
 
     @routes.get("/api/{username}/groups")
     @check_request
     async def async_get_groups(self, request: web.Request):
         """Handle requests to retrieve all rooms/groups."""
         groups = await self.__async_get_all_groups()
-        return web.json_response(groups)
+        return json_response_nonunicode(groups)
 
     @routes.get("/api/{username}/groups/{group_id}")
     @check_request
@@ -221,7 +222,7 @@ class HueApi:
         group_id = request.match_info["group_id"]
         groups = await self.__async_get_all_groups()
         result = groups.get(group_id, {})
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @routes.put("/api/{username}/groups/{group_id}/action")
     @check_request
@@ -236,14 +237,14 @@ class HueApi:
         response = await self.__async_create_hue_response(
             request.path, request_data, username
         )
-        return web.json_response(response)
+        return json_response_nonunicode(response)
 
     @routes.post("/api/{username}/groups")
     @check_request
     async def async_create_group(self, request: web.Request, request_data: dict):
         """Handle requests to create a new group."""
         item_id = await self.__async_create_local_item(request_data, "groups")
-        return web.json_response([{"success": {"id": item_id}}])
+        return json_response_nonunicode([{"success": {"id": item_id}}])
 
     @routes.put("/api/{username}/groups/{group_id}")
     @check_request
@@ -292,7 +293,7 @@ class HueApi:
         response = await self.__async_create_hue_response(
             request.path, request_data, username
         )
-        return web.json_response(response)
+        return json_response_nonunicode(response)
 
     @routes.get("/api/{username}/{itemtype:(?:scenes|rules|resourcelinks)}")
     @check_request
@@ -300,7 +301,7 @@ class HueApi:
         """Handle requests to retrieve localitems (e.g. scenes)."""
         itemtype = request.match_info["itemtype"]
         result = await self.config.async_get_storage_value(itemtype)
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @routes.get("/api/{username}/{itemtype:(?:scenes|rules|resourcelinks)}/{item_id}")
     @check_request
@@ -310,7 +311,7 @@ class HueApi:
         itemtype = request.match_info["itemtype"]
         items = await self.config.async_get_storage_value(itemtype)
         result = items.get(item_id, {})
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @routes.post("/api/{username}/{itemtype:(?:scenes|rules|resourcelinks)}")
     @check_request
@@ -318,7 +319,7 @@ class HueApi:
         """Handle requests to create a new localitem."""
         itemtype = request.match_info["itemtype"]
         item_id = await self.__async_create_local_item(request_data, itemtype)
-        return web.json_response([{"success": {"id": item_id}}])
+        return json_response_nonunicode([{"success": {"id": item_id}}])
 
     @routes.put("/api/{username}/{itemtype:(?:scenes|rules|resourcelinks)}/{item_id}")
     @check_request
@@ -335,7 +336,7 @@ class HueApi:
         response = await self.__async_create_hue_response(
             request.path, request_data, username
         )
-        return web.json_response(response)
+        return json_response_nonunicode(response)
 
     @routes.delete(
         "/api/{username}/{itemtype:(?:scenes|rules|resourcelinks|groups)}/{item_id}"
@@ -347,21 +348,21 @@ class HueApi:
         itemtype = request.match_info["itemtype"]
         await self.config.async_delete_storage_value(itemtype, item_id)
         result = [{"success": f"/{itemtype}/{item_id} deleted."}]
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @check_request
     async def async_get_discovery_config(self, request: web.Request):
         """Process a request to get the (basic) config of this emulated bridge."""
         await self.config.async_enable_link_mode_discovery()
         result = await self.__async_get_bridge_config(False)
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @routes.get("/api/{username}/config")
     @check_request
     async def async_get_config(self, request: web.Request):
         """Process a request to get the (full) config of this emulated bridge."""
         result = await self.__async_get_bridge_config(True)
-        return web.json_response(result)
+        return json_response_nonunicode(result)
 
     @routes.put("/api/{username}/config")
     @check_request
@@ -373,7 +374,7 @@ class HueApi:
         response = await self.__async_create_hue_response(
             request.path, request_data, username
         )
-        return web.json_response(response)
+        return json_response_nonunicode(response)
 
     @routes.get("/api/{username}{tail:/?}")
     @check_request
@@ -405,21 +406,21 @@ class HueApi:
             },
         }
 
-        return web.json_response(json_response)
+        return json_response_nonunicode(json_response)
 
     @routes.get("/api/{username}/sensors")
     @check_request
     async def async_get_sensors(self, request: web.Request):
         """Return sensors on the (virtual) bridge."""
         # not supported yet but prevent errors
-        return web.json_response({})
+        return json_response_nonunicode({})
 
     @routes.get("/api/{username}/sensors/new")
     @check_request
     async def async_get_new_sensors(self, request: web.Request):
         """Return all new discovered sensors on the (virtual) bridge."""
         # not supported yet but prevent errors
-        return web.json_response({})
+        return json_response_nonunicode({})
 
     @routes.get("/description.xml")
     @check_request
@@ -497,7 +498,7 @@ class HueApi:
             "streaming": {"available": 1, "total": 10, "channels": 10},
         }
 
-        return web.json_response(json_response)
+        return json_response_nonunicode(json_response)
 
     async def async_unknown_request(self, request: web.Request):
         """Handle unknown requests (catch-all)."""

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -61,7 +61,7 @@ def update_dict(dict1, dict2):
 
 
 def json_response_nonunicode(data):
-    """Sends json response in raw format instead of converting to ascii / unicode."""
+    """Send json response in raw format instead of converting to ascii / unicode."""
     return web.Response(text=json.dumps(data, ensure_ascii=False), content_type='application/json')
 
 

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -5,6 +5,7 @@ import os
 import socket
 from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
 from typing import Union
+from aiohttp import web
 
 import slugify as unicode_slug
 
@@ -59,6 +60,10 @@ def update_dict(dict1, dict2):
             dict1[key] = value
 
 
+def json_response_nonunicode(data):
+    return web.Response(text=json.dumps(data, ensure_ascii=False), content_type='application/json')
+
+
 def load_json(filename: str):
     """Load JSON from file."""
     try:
@@ -75,7 +80,7 @@ def save_json(filename: str, data: dict):
     if os.path.isfile(filename):
         os.replace(filename, safe_copy)
     try:
-        json_data = json.dumps(data, sort_keys=True, indent=4)
+        json_data = json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False)
         with open(filename, "w") as file_obj:
             file_obj.write(json_data)
     except IOError:

--- a/emulated_hue/utils.py
+++ b/emulated_hue/utils.py
@@ -61,6 +61,7 @@ def update_dict(dict1, dict2):
 
 
 def json_response_nonunicode(data):
+    """Sends json response in raw format instead of converting to ascii / unicode."""
     return web.Response(text=json.dumps(data, ensure_ascii=False), content_type='application/json')
 
 


### PR DESCRIPTION
Sends the data that is non unicode directly instead of converting it to unicode first and then sending.
This solves the issue where åäö gets turned into ��� on android and empty text on iOS (personally tested on both platforms on the official app).
I have not tested third party apps except Hue Essentials, and seems to be working there as well.

After inspecting the API compared to a real Hue bridge with postman sending the same requests i got the following responses
Real Hue Bridge:
```
"1": {
        "name": "Kök",
        "lights": [
            "4",
            "5",
            "6",
            "7",
            "8",
            "9",
            "10",
            "14"
        ],
        "sensors": [],
        "type": "Room",
        "state": {
            "all_on": true,
            "any_on": true
        },
        "recycle": false,
        "class": "Kitchen",
        "action": {
            "on": true,
            "bri": 253,
            "ct": 336,
            "alert": "none",
            "colormode": "ct"
        }
    },
```
Emulated Hue Bridge:
```
"4": {
        "class": "Kitchen",
        "lights": [
            "15",
            "16",
            "17",
            "18",
            "19",
            "20",
            "21",
            "22"
        ],
        "name": "K\u00f6k",
        "type": "Room"
    }
```

And with the changes in this pull request the \u00f6 gets replaced with the actual character ö like the real hue bridge.
So the result will now instead be the following:
```
"4": {
        "class": "Kitchen",
        "lights": [
            "15",
            "16",
            "17",
            "18",
            "19",
            "20",
            "21",
            "22"
        ],
        "name": "Kök",
        "type": "Room"
    }
```

Some final notes:

* this might impact other regions as well so needs to be tested by others, i doubt it will break for others but you never really know (since we don't really know how the app operates internally).
* There might be a better way of handling this, as i have not actually coded that much in python before (coming from a c#/asp.net background), so please if anything can be done in a better way tell me.

Solves Issue #19 and Issue #30 